### PR TITLE
Standard env vars and network host, fix action-group volume name

### DIFF
--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -77,7 +77,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: discovery.zen.ping.unicast.hosts
+        - name: DISCOVERY_SERVICE
           value: {{ template "opendistro-es.fullname" . }}-discovery
         - name: KUBERNETES_NAMESPACE
           valueFrom:

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -82,7 +82,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: discovery.zen.ping.unicast.hosts
+        - name: DISCOVERY_SERVICE
           value: {{ template "opendistro-es.fullname" . }}-discovery
         - name: KUBERNETES_NAMESPACE
           valueFrom:

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-master-deploy.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-master-deploy.yaml
@@ -68,7 +68,7 @@ spec:
         - name: NODE_DATA
           value: "false"
         - name: NETWORK_HOST
-          value: "0.0.0.0"
+          value: "_eth0_"
         - name: HTTP_ENABLE
           value: "true"
     {{- if .Values.elasticsearch.transportKeyPassphrase.enabled}}
@@ -83,7 +83,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: discovery.zen.ping.unicast.hosts
+        - name: DISCOVERY_SERVICE
           value: {{ template "opendistro-es.fullname" . }}-discovery
         - name: KUBERNETES_NAMESPACE
           valueFrom:
@@ -212,7 +212,7 @@ spec:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
       {{- end }}
       {{- if .Values.elasticsearch.securityConfig.actionGroupsSecret }}
-      - name: action-group
+      - name: action-groups
         secret:
           secretName: {{ .Values.elasticsearch.securityConfig.actionGroupsSecret }}
       {{- end }}


### PR DESCRIPTION
*Description of changes:*

* Standard env vars from `discovery.zen.ping.unicast.hosts` to `DISCOVERY_SERVICE`
* Standard network host from `0.0.0.0` to `_eth0_` in Master node (as it was done in client and data nodes)
* Fix `action-groups` volume reference name as it was being used on volume mount in plural on [line 171](https://github.com/Viasat/opendistro-elastic-community/compare/feat/helm-chart...fsschmitt:feat/helm-chart?expand=1#diff-cf527d3324069849fcc053cabfddfccfR171) at `es-master-deploy.yaml`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
