### PR TITLE
Fix indentation on annotations for services

### DIFF
--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/Chart.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: opendistro-es
 sources:
 - https://pages.git.viasat.com/ATG/charts
-version: 1.0.0
+version: 1.0.1

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-service.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/elasticsearch/es-service.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-{{- toYaml .Values.elasticsearch.client.service.annotations | indent 4 }}
+{{ toYaml .Values.elasticsearch.client.service.annotations | indent 4 }}
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
     role: client

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/kibana-service.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/templates/kibana/kibana-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-{{- toYaml .Values.kibana.service.annotations | indent 4 }}
+{{ toYaml .Values.kibana.service.annotations | indent 4 }}
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
   name: {{ template "opendistro-es.fullname" . }}-kibana-svc


### PR DESCRIPTION
Attempting to set annotations on services resulted in an error such as `error converting YAML to JSON: yaml: line 3: mapping values are not allowed in this context` due to invalid YAML being rendered.  For example, when setting the following:

```
kibana:
  service:
    annotations:
      alb.ingress.kubernetes.io/healthcheck-path: "/login"
```
The following kibana service YAML is rendered by Helm:
```
---
# Source: opendistro-es/templates/kibana/kibana-service.yaml

apiVersion: v1
kind: Service
metadata:
  annotations:    alb.ingress.kubernetes.io/healthcheck-path: /login
    
  labels:
    app: release-name-opendistro-es
    chart: "opendistro-es-1.0.0"
    release: "release-name"
    heritage: "Tiller"
  name: release-name-opendistro-es-kibana-svc
spec:
  ports:
  - name: kibana-svc
    port: 443
    targetPort: 5601
  selector:
    app: release-name-opendistro-es-kibana
  type: ClusterIP
```

The annotations being on the same line as the annotations key results in the error about mapping values not being allowed.  With this change, the newline/indentation issue is fixed resulting in the following YAML and annotations being applied successfully:
```
---
# Source: opendistro-es/templates/kibana/kibana-service.yaml

apiVersion: v1
kind: Service
metadata:
  annotations:
    alb.ingress.kubernetes.io/healthcheck-path: /login
    
  labels:
    app: release-name-opendistro-es
    chart: "opendistro-es-1.0.0"
    release: "release-name"
    heritage: "Tiller"
  name: release-name-opendistro-es-kibana-svc
spec:
  ports:
  - name: kibana-svc
    port: 443
    targetPort: 5601
  selector:
    app: release-name-opendistro-es-kibana
  type: ClusterIP
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
