### PR TITLE
Optionally install the ES exporter chart

### DIFF
--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/requirements.lock
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: elasticsearch-exporter
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.1
+digest: sha256:33fee3426fdcb82841bae6f7c0b1030dc076c67180fa6263367d9509f38ec8d6
+generated: 2019-12-05T15:54:02.708888859-05:00

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/requirements.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: elasticsearch-exporter
+  version: 2.1.1
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: elasticsearch-exporter.enabled

--- a/open-distro-elasticsearch-kubernetes/helm/opendistro-es/values.yaml
+++ b/open-distro-elasticsearch-kubernetes/helm/opendistro-es/values.yaml
@@ -343,3 +343,7 @@ elasticsearch:
 
 nameOverride: ""
 fullnameOverride: ""
+
+elasticsearch-exporter:
+  enabled: false
+  # See https://github.com/helm/charts/blob/master/stable/elasticsearch-exporter/values.yaml for options


### PR DESCRIPTION
This will optionally install the stable/elasticsearch-exporter chart for exposing metrics to prometheus
